### PR TITLE
Addition of astream config parameter 'recursion_limit'

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -134,7 +134,8 @@ async def run_agent_with_streaming(user_input: str, settings: Dict[str, bool] = 
     config = {
         "configurable": {
             "thread_id": thread_id
-        }
+        },
+        "recursion_limit": 50
     }
 
     # Set the workflow_active flag to True


### PR DESCRIPTION
Addition of parameter to astream config variable, 'recursion_limit', that allows the explicit setting of the LangGraph node traversal limit. Set to 50, please change as needed.