### PR TITLE
Addition of configurable recursion_limit var in settings.yml

### DIFF
--- a/configuration/settings.yml.example
+++ b/configuration/settings.yml.example
@@ -16,10 +16,16 @@ test_name: ""
 # Maximum number of steps to execute in an action plan before escalating
 max_steps: 15
 
+# Step mode - When true, pauses between execution of each node in the workflow and waits for user input before proceeding
+step_mode: false
+
 # Adaptive mode - when true, allows the Action Analyzer to recommend new_action steps
 adaptive_mode: true
 
-golden_rules:
+# Golden rules - a list of rules that must always be followed by each agent
   - "rule1"
   - "rule2"
   - "rule3"
+
+# Maximum number of node traversals the graph is allowed before hitting a GraphRecursionLimit error
+recursion_limit: 50

--- a/graph.py
+++ b/graph.py
@@ -89,7 +89,10 @@ def load_settings(file_path: str) -> Dict[str, Any]:
         "test_mode": False,
         "test_name": "",
         "max_steps": 15,
-        "golden_rules": []
+        "step_mode:": False,
+        "adaptive_mode:": True,
+        "golden_rules": [],
+        "recursion_limit": 50
     }
     
     try:
@@ -169,6 +172,16 @@ def load_network_inventory(file_path: str) -> Dict[str, Any]:
     except Exception as e:
         logger.error(f"Error loading inventory: {str(e)}")
         return default_inventory
+    
+# Set the graph invocation paramters
+def set_invoke_config(thread_id, recursion_limit):
+    config = {
+        "configurable": {
+            "thread_id": thread_id
+        },
+        "recursion_limit": recursion_limit
+    }
+    return config
 
 # Load network inventory
 network_inventory = load_network_inventory(inventory_path)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,6 +22,9 @@ from utils.streamlit_logger import get_streamlit_logger
 # Import settings loader from graph.py
 from graph import load_settings, settings_path
 
+# Import graph invocation config parameter function from graph.py
+from graph import set_invoke_config
+
 # Create a main logger for the streamlit app
 logger = get_streamlit_logger("streamlit_app")
 
@@ -131,12 +134,7 @@ async def run_agent_with_streaming(user_input: str, settings: Dict[str, bool] = 
     if settings is None:
         settings = {"simulation_mode": True, "debug_mode": False}
         
-    config = {
-        "configurable": {
-            "thread_id": thread_id
-        },
-        "recursion_limit": 50
-    }
+    config = set_invoke_config(thread_id, settings.get("recursion_limit", 25))
 
     # Set the workflow_active flag to True
     st.session_state.workflow_active = True


### PR DESCRIPTION
Addition of function to 'graphy.py' (set_invoke_config) that sets the configuration parameters for the astream calls in streamlit_app.py. Variable can be set in settings.yml, otherwise will default to the value of '50' set by 'default_settings' in the 'load_settings' function.

Some other minor modifications made to the settings example file as well.